### PR TITLE
Updated browser-sync to version 2.9.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-sourcemaps": "1.6.0",
     "browserify": "11.2.0",
     "watchify": "3.4.0",
-    "browser-sync": "2.9.9",
+    "browser-sync": "2.9.10",
     "vinyl-transform": "1.0.0",
     "vinyl-source-stream": "1.1.0",
     "vinyl-buffer": "1.0.0",


### PR DESCRIPTION
:rocket:

browser-sync just published version 2.9.10, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 3 commits (ahead by 3, behind by 0).
- [fece1f7](https://github.com/BrowserSync/browser-sync/commit/fece1f754c981140a35f75e4557a5fe215362b62): 2.9.10
- [a18cdc3](https://github.com/BrowserSync/browser-sync/commit/a18cdc3cd6d7f21f45f38e857e15a73d282c9e21): tests: cleanup some lingering state in legacy tests
- [ddd4213](https://github.com/BrowserSync/browser-sync/commit/ddd4213fcfaba25a35a5cca6dc63d23243546be8): fix(cleanup): close any watchers registered in options - fixes #855

See the [full diff](https://github.com/BrowserSync/browser-sync/compare/fe716bb382172df638bbea74aea6e6f988e80515...fece1f754c981140a35f75e4557a5fe215362b62).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
